### PR TITLE
[refactor] BudgetProgressCard에 CommonCard 적용

### DIFF
--- a/src/components/BudgetProgressCard/BudgetProgressCard.tsx
+++ b/src/components/BudgetProgressCard/BudgetProgressCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import ChevronDown from "@/assets/icons/general/chevron-down.svg";
+import { CommonCard } from "@/components";
 
 import {
   calcBudgetState,
@@ -32,15 +33,15 @@ function ProgressBar({ ratio, fillFromRight }: BarProps) {
   const r = clamp01(ratio);
 
   return (
-    <div className="relative h-2 w-68 overflow-hidden rounded-full bg-(--gray-20)">
+    <div className="relative h-2 w-68 overflow-hidden rounded-full bg-gray-20">
       {!fillFromRight ? (
         <div
-          className="h-full rounded-full bg-(--primary-50)"
+          className="h-full rounded-full bg-primary-50"
           style={{ width: `${r * 100}%` }}
         />
       ) : (
         <div
-          className="absolute right-0 top-0 h-full rounded-full bg-(--primary-50)"
+          className="absolute right-0 top-0 h-full rounded-full bg-primary-50"
           style={{ width: `${r * 100}%` }}
         />
       )}
@@ -62,7 +63,10 @@ export default function BudgetProgressCard({
     [startDate, endDate, currentDate]
   );
 
-  const midDate = useMemo(() => calcMidDateCompact(startDate, endDate), [startDate, endDate]);
+  const midDate = useMemo(
+    () => calcMidDateCompact(startDate, endDate),
+    [startDate, endDate]
+  );
 
   const state = useMemo(
     () => calcBudgetState(targetBudget, spentAmount),
@@ -79,18 +83,17 @@ export default function BudgetProgressCard({
   const amount = state.isOver ? state.overAmount : state.savedAmount;
 
   return (
-    <section className="h-51.75 w-77.25 overflow-hidden rounded-[14px] border-[0.5px] border-(--primary-60) bg-(--surface-background) px-5 py-5">
+    <CommonCard className="h-51.75 px-5 py-5">
       <div className="flex flex-col gap-1">
-        <h3 className="text-sub1 text-(--gray-10)">{title}</h3>
-        <p className="text-caption2 text-(--gray-60)">
+        <h3 className="text-sub1 text-gray-10">{title}</h3>
+        <p className="text-caption2 text-gray-60">
           {formatDotDate(startDate)} - {formatDotDate(endDate)}
         </p>
       </div>
 
       <div className="mt-4">
         <ProgressBar ratio={timeRatio} />
-
-        <div className="mt-1 flex w-68 items-center justify-between text-[6px] text-(--gray-50)">
+        <div className="mt-1 flex w-68 items-center justify-between text-[6px] text-gray-50">
           <span>{timeStartLabel}</span>
           <span>{timeMidLabel}</span>
           <span>{timeEndLabel}</span>
@@ -98,12 +101,13 @@ export default function BudgetProgressCard({
       </div>
 
       <div className="mt-5">
-        <p className="text-sub1 text-(--gray-10)">
+        <p className="text-sub1 text-gray-10">
           지금까지 {formatCurrencyKRW(amount)}원을{" "}
-          <span className="text-(--primary-50)">{keyword}</span>했어요
+          <span className="text-primary-50">{keyword}</span>했어요
         </p>
-        <p className="mt-1 text-caption2 text-(--gray-60)">
-          목표 예산 {formatCurrencyKRW(targetBudget)}원에서 {formatCurrencyKRW(spentAmount)}원 사용
+        <p className="mt-1 text-caption2 text-gray-60">
+          목표 예산 {formatCurrencyKRW(targetBudget)}원에서{" "}
+          {formatCurrencyKRW(spentAmount)}원 사용
         </p>
       </div>
 
@@ -118,15 +122,17 @@ export default function BudgetProgressCard({
             className="absolute -top-7 flex -translate-x-1/2 flex-col items-center"
             style={{ left: `${state.indicatorLeftPercent}%` }}
           >
-            <span className="text-[10px] text-(--primary-50)">{state.badgeText}</span>
+            <span className="text-[10px] text-primary-50">
+              {state.badgeText}
+            </span>
             <img src={ChevronDown} alt="" className="mt-pt h-2.5 w-2.5" />
           </div>
         </div>
 
         <div className="mt-2 flex w-68 items-center justify-end">
-          <span className="text-[6px] text-(--gray-30)">{rightBottomLabel}</span>
+          <span className="text-[6px] text-gray-30">{rightBottomLabel}</span>
         </div>
       </div>
-    </section>
+    </CommonCard>
   );
 }

--- a/src/components/common/CommonCard/CommonCard.tsx
+++ b/src/components/common/CommonCard/CommonCard.tsx
@@ -24,7 +24,7 @@ export default function CommonCard({
         // 고정 width 309
         "w-77.25",
         "border-[0.5px] border-primary-60",
-        "rounded-2xl bg-(--color-surface-card)]",
+        "overflow-hidden rounded-[14px] bg-transparent",
         "px-5 py-4",
         className,
       ].join(" ")}
@@ -32,7 +32,7 @@ export default function CommonCard({
       {title ? (
         <h2
           className={[
-            "text-base font-semibold text(--color-text-primary)",
+            "text-sub1-size font-semibold text-gray-10",
             titleClassName,
           ].join(" ")}
         >


### PR DESCRIPTION
## 🔍 관련된 이슈

- closed #32 

## 📝 작업 내용

- BudgetProgressCard의 컨테이너(section) 스타일을 CommonCard로 대체하여 중복 제거
- CommonCard를 투명 배경(bg-transparent)으로 고정하여 기존 UI와 동일하게 유지
- 기존 테스트 페이지에서 렌더링 확인 (UI 변경 없이 동작 확인)


## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되었고 빌드되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
