### PR TITLE
[refactor] MyPage Progressbar 수정

### DIFF
--- a/src/components/BudgetProgressCard/BudgetProgressCard.tsx
+++ b/src/components/BudgetProgressCard/BudgetProgressCard.tsx
@@ -35,15 +35,9 @@ function ProgressBar({ ratio, fillFromRight }: BarProps) {
   return (
     <div className="relative h-2 w-68 overflow-hidden rounded-full bg-gray-20">
       {!fillFromRight ? (
-        <div
-          className="h-full rounded-full bg-primary-50"
-          style={{ width: `${r * 100}%` }}
-        />
+        <div className="h-full rounded-full bg-primary-50" style={{ width: `${r * 100}%` }} />
       ) : (
-        <div
-          className="absolute right-0 top-0 h-full rounded-full bg-primary-50"
-          style={{ width: `${r * 100}%` }}
-        />
+        <div className="absolute right-0 top-0 h-full rounded-full bg-primary-50" style={{ width: `${r * 100}%` }} />
       )}
     </div>
   );
@@ -58,20 +52,24 @@ export default function BudgetProgressCard({
   spentAmount,
   rightBottomLabel = "총 목표 예산",
 }: BudgetProgressCardProps) {
-  const timeRatio = useMemo(
-    () => calcTimeRatio(startDate, endDate, currentDate),
-    [startDate, endDate, currentDate]
-  );
+  const timeRatio = useMemo(() => calcTimeRatio(startDate, endDate, currentDate), [startDate, endDate, currentDate]);
 
-  const midDate = useMemo(
-    () => calcMidDateCompact(startDate, endDate),
-    [startDate, endDate]
-  );
+  const midDate = useMemo(() => calcMidDateCompact(startDate, endDate), [startDate, endDate]);
 
-  const state = useMemo(
-    () => calcBudgetState(targetBudget, spentAmount),
-    [targetBudget, spentAmount]
-  );
+  const state = useMemo(() => {
+    if (targetBudget <= 0) {
+      return {
+        isOver: false,
+        overAmount: 0,
+        savedAmount: 0,
+        overRatio: 0,
+        savingRatio: 0,
+        indicatorLeftPercent: 100,
+        badgeText: "0%",
+      };
+    }
+    return calcBudgetState(targetBudget, spentAmount);
+  }, [targetBudget, spentAmount]);
 
   const timeStartLabel = formatDotDate(startDate);
   const timeMidLabel = midDate
@@ -85,8 +83,7 @@ export default function BudgetProgressCard({
   return (
     <CommonCard className="h-58 px-5 py-5">
       <div className="flex flex-col gap-1">
-        <h3 className="text-sub1-size font-semibold text-gray-10">{title}</h3>
-
+        <h3 className="text-sub1 text-gray-10">{title}</h3>
         <p className="text-caption2 text-gray-60">
           {formatDotDate(startDate)} - {formatDotDate(endDate)}
         </p>
@@ -102,23 +99,18 @@ export default function BudgetProgressCard({
       </div>
 
       <div className="mt-5">
-        <p className="text-sub1-size font-semibold text-gray-10">
-          지금까지 {formatCurrencyKRW(amount)}원을{" "}
-          <span className="text-primary-50">{keyword}</span>했어요
+        <p className="text-sub1 text-gray-10">
+          지금까지 {formatCurrencyKRW(amount)}원을 <span className="text-primary-50">{keyword}</span>했어요
         </p>
 
         <p className="mt-1 text-caption2 text-gray-60">
-          목표 예산 {formatCurrencyKRW(targetBudget)}원에서{" "}
-          {formatCurrencyKRW(spentAmount)}원 사용
+          목표 예산 {formatCurrencyKRW(targetBudget)}원에서 {formatCurrencyKRW(spentAmount)}원 사용
         </p>
       </div>
 
       <div className="mt-4">
         <div className="relative w-68">
-          <ProgressBar
-            ratio={state.isOver ? state.overRatio : state.savingRatio}
-            fillFromRight={state.isOver}
-          />
+          <ProgressBar ratio={state.isOver ? state.overRatio : state.savingRatio} fillFromRight={state.isOver} />
 
           <div
             className="absolute -top-7 flex -translate-x-1/2 flex-col items-center"

--- a/src/pages/mypage/MyPageMainPage.tsx
+++ b/src/pages/mypage/MyPageMainPage.tsx
@@ -7,23 +7,12 @@ import HomeIcon from "@/assets/icons/general/home.svg";
 import { CommonCard } from "@/components";
 import { AvartarIcon, ChevronRightIcon } from "@/assets/icons";
 
-
 type CurrentRecord = {
   startDate: string;
   endDate: string;
   targetBudget: number;
   spentAmount: number;
 };
-
-function EmptyLargeCard({ message }: { message: string }) {
-  return (
-    <CommonCard className="h-51.75 px-5 py-5">
-      <div className="flex h-full items-center justify-center">
-        <p className="text-body2 text-gray-50">{message}</p>
-      </div>
-    </CommonCard>
-  );
-}
 
 function EmptySmallCard({ message }: { message: string }) {
   return (
@@ -44,7 +33,6 @@ function SummaryCard({ saved, over }: { saved: number; over: number }) {
             <span className="text-primary-50">절약</span>
             <span className="text-gray-10">한 기간</span>
           </p>
-
           <p className="mt-1 text-[15px] font-semibold text-gray-10">{saved}회</p>
         </div>
 
@@ -53,7 +41,6 @@ function SummaryCard({ saved, over }: { saved: number; over: number }) {
             <span className="text-primary-50">초과</span>
             <span className="text-gray-10">한 기간</span>
           </p>
-
           <p className="mt-1 text-[15px] font-semibold text-gray-10">{over}회</p>
         </div>
       </div>
@@ -61,23 +48,26 @@ function SummaryCard({ saved, over }: { saved: number; over: number }) {
   );
 }
 
+function addDays(d: Date, days: number) {
+  const nd = new Date(d);
+  nd.setDate(nd.getDate() + days);
+  return nd;
+}
+
+function formatYMD(d: Date) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 export default function MyPageMainPage() {
   const navigate = useNavigate();
 
-  const currentRecord: CurrentRecord | null = useMemo(
-    () => ({
-      startDate: "2026-01-01",
-      endDate: "2026-01-31",
-      targetBudget: 250000,
-      spentAmount: 15000,
-    }),
-    []
-  );
+const currentRecord: CurrentRecord | null = useMemo(() => null, []);
 
-  const summary: { saved: number; over: number } | null = useMemo(
-    () => ({ saved: 6, over: 4 }),
-    []
-  );
+
+  const summary: { saved: number; over: number } | null = useMemo(() => ({ saved: 6, over: 4 }), []);
 
   const user = {
     name: "길동",
@@ -86,6 +76,22 @@ export default function MyPageMainPage() {
     startText: "2026.01.26 시작",
   };
 
+  const emptyPeriod = useMemo(() => {
+    const start = new Date();
+    const end = addDays(start, 29);
+    return { startDate: formatYMD(start), endDate: formatYMD(end) };
+  }, []);
+
+  const progressProps: CurrentRecord = useMemo(() => {
+    if (currentRecord) return currentRecord;
+    return {
+      startDate: emptyPeriod.startDate,
+      endDate: emptyPeriod.endDate,
+      targetBudget: 0,
+      spentAmount: 0,
+    };
+  }, [currentRecord, emptyPeriod.endDate, emptyPeriod.startDate]);
+
   return (
     <main className="flex h-full w-full flex-col">
       <MyPageTopBar />
@@ -93,7 +99,7 @@ export default function MyPageMainPage() {
       <section className="mt-1 px-4">
         <div className="flex items-center gap-3">
           <div className="flex h-13 w-13 items-center justify-center rounded-full">
-             <AvartarIcon />
+            <AvartarIcon />
           </div>
 
           <button
@@ -112,7 +118,7 @@ export default function MyPageMainPage() {
         </div>
       </section>
 
-   <div className="mt-6 h-px w-[calc(100%+32px)] -ml-4 bg-gray-50" />
+      <div className="mt-6 h-px w-[calc(100%+32px)] -ml-4 bg-gray-50" />
 
       <section className="mt-6 px-4">
         <p className="text-sub2 text-gray-10">
@@ -124,23 +130,15 @@ export default function MyPageMainPage() {
       </section>
 
       <section className="mt-6 flex flex-col items-center gap-5 px-4">
-        {currentRecord ? (
-          <BudgetProgressCard
-            title="현재 진행 중인 지출 기록"
-            startDate={currentRecord.startDate}
-            endDate={currentRecord.endDate}
-            targetBudget={currentRecord.targetBudget}
-            spentAmount={currentRecord.spentAmount}
-          />
-        ) : (
-          <EmptyLargeCard message="현재 진행 중인 지출 기록이 없습니다" />
-        )}
+        <BudgetProgressCard
+          title="현재 진행 중인 지출 기록"
+          startDate={progressProps.startDate}
+          endDate={progressProps.endDate}
+          targetBudget={progressProps.targetBudget}
+          spentAmount={progressProps.spentAmount}
+        />
 
-        {summary ? (
-          <SummaryCard saved={summary.saved} over={summary.over} />
-        ) : (
-          <EmptySmallCard message="완료한 지출 기록이 없습니다" />
-        )}
+        {summary ? <SummaryCard saved={summary.saved} over={summary.over} /> : <EmptySmallCard message="완료한 지출 기록이 없습니다" />}
       </section>
 
       <div className="mt-auto w-full">


### PR DESCRIPTION
## 🔍 관련된 이슈
- closed #48 

## 📝 작업 내용
- 진행 중인 지출 기록이 없을 때 Empty CommonCard 대신 ProgressBar 0% 상태로 표시하도록 변경
- 마이페이지 메인에서 `currentRecord` 분기 로직 수정(빈 상태에서도 BudgetProgressCard 렌더)
- BudgetProgressCard의 0% 케이스(라벨/바/표시) UI가 깨지지 않도록 처리


## 📸 스크린샷
<img width="268" height="585" alt="스크린샷 2026-02-04 오전 1 40 56" src="https://github.com/user-attachments/assets/5857dbfa-9346-49ee-b036-e1deb1af8bb7" />


## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되었고 빌드되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
