### PR TITLE
[Design] MyPage 진행중 상태바 수정

### DIFF
--- a/src/components/BudgetProgressCard/BudgetProgressCard.tsx
+++ b/src/components/BudgetProgressCard/BudgetProgressCard.tsx
@@ -33,15 +33,12 @@ function ProgressBar({ ratio, fillFromRight }: BarProps) {
   const r = clamp01(ratio);
 
   return (
-    <div className="bg-gray-20 relative h-2 w-68 overflow-hidden rounded-full">
+    <div className="relative h-2 w-68 overflow-hidden rounded-full bg-gray-20">
       {!fillFromRight ? (
-        <div
-          className="bg-primary-50 h-full rounded-full"
-          style={{ width: `${r * 100}%` }}
-        />
+        <div className="h-full rounded-full bg-primary-50" style={{ width: `${r * 100}%` }} />
       ) : (
         <div
-          className="bg-primary-50 absolute top-0 right-0 h-full rounded-full"
+          className="absolute right-0 top-0 h-full rounded-full bg-primary-50"
           style={{ width: `${r * 100}%` }}
         />
       )}
@@ -60,13 +57,18 @@ export default function BudgetProgressCard({
 }: BudgetProgressCardProps) {
   const timeRatio = useMemo(
     () => calcTimeRatio(startDate, endDate, currentDate),
-    [startDate, endDate, currentDate],
+    [startDate, endDate, currentDate]
   );
 
-  const midDate = useMemo(
-    () => calcMidDateCompact(startDate, endDate),
-    [startDate, endDate],
-  );
+  const midDate = useMemo(() => calcMidDateCompact(startDate, endDate), [startDate, endDate]);
+
+  const timeStartLabel = formatDotDate(startDate);
+  const timeMidLabel = midDate
+    ? `${midDate.slice(0, 4)}.${midDate.slice(4, 6)}.${midDate.slice(6, 8)}`
+    : "";
+  const timeEndLabel = formatDotDate(endDate);
+
+  const isNoSpent = spentAmount <= 0;
 
   const state = useMemo(() => {
     if (targetBudget <= 0) {
@@ -82,12 +84,6 @@ export default function BudgetProgressCard({
     }
     return calcBudgetState(targetBudget, spentAmount);
   }, [targetBudget, spentAmount]);
-
-  const timeStartLabel = formatDotDate(startDate);
-  const timeMidLabel = midDate
-    ? `${midDate.slice(0, 4)}.${midDate.slice(4, 6)}.${midDate.slice(6, 8)}`
-    : "";
-  const timeEndLabel = formatDotDate(endDate);
 
   const keyword = state.isOver ? "초과" : "절약";
   const amount = state.isOver ? state.overAmount : state.savedAmount;
@@ -110,40 +106,47 @@ export default function BudgetProgressCard({
         </div>
       </div>
 
-      <div className="mt-5">
-        <p className="text-sub1 text-gray-10">
-          지금까지 {formatCurrencyKRW(amount)}원을{" "}
-          <span className="text-primary-50">{keyword}</span>했어요
-        </p>
+      {isNoSpent ? (
+        <div className="mt-6">
+          <p className="text-body2 text-gray-50 whitespace-pre-line">
+            아직 지출 기록이 없어요{"\n"}지출을 입력하면 금액이 표시 돼요
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-5">
+            <p className="text-sub1 text-gray-10">
+              지금까지 {formatCurrencyKRW(amount)}원을{" "}
+              <span className="text-primary-50">{keyword}</span>했어요
+            </p>
 
-        <p className="text-caption2 text-gray-60 mt-1">
-          목표 예산 {formatCurrencyKRW(targetBudget)}원에서{" "}
-          {formatCurrencyKRW(spentAmount)}원 사용
-        </p>
-      </div>
-
-      <div className="mt-4">
-        <div className="relative w-68">
-          <ProgressBar
-            ratio={state.isOver ? state.overRatio : state.savingRatio}
-            fillFromRight={state.isOver}
-          />
-
-          <div
-            className="absolute -top-7 flex -translate-x-1/2 flex-col items-center"
-            style={{ left: `${state.indicatorLeftPercent}%` }}
-          >
-            <span className="text-primary-50 text-[10px]">
-              {state.badgeText}
-            </span>
-            <img src={ChevronDown} alt="" className="mt-pt h-2.5 w-2.5" />
+            <p className="mt-1 text-caption2 text-gray-60">
+              목표 예산 {formatCurrencyKRW(targetBudget)}원에서 {formatCurrencyKRW(spentAmount)}원 사용
+            </p>
           </div>
-        </div>
 
-        <div className="mt-2 flex w-68 items-center justify-end">
-          <span className="text-gray-30 text-[6px]">{rightBottomLabel}</span>
-        </div>
-      </div>
+          <div className="mt-4">
+            <div className="relative w-68">
+              <ProgressBar
+                ratio={state.isOver ? state.overRatio : state.savingRatio}
+                fillFromRight={state.isOver}
+              />
+
+              <div
+                className="absolute -top-7 flex -translate-x-1/2 flex-col items-center"
+                style={{ left: `${state.indicatorLeftPercent}%` }}
+              >
+                <span className="text-[10px] text-primary-50">{state.badgeText}</span>
+                <img src={ChevronDown} alt="" className="mt-pt h-2.5 w-2.5" />
+              </div>
+            </div>
+
+            <div className="mt-2 flex w-68 items-center justify-end">
+              <span className="text-[6px] text-gray-30">{rightBottomLabel}</span>
+            </div>
+          </div>
+        </>
+      )}
     </CommonCard>
   );
 }

--- a/src/pages/mypage/MyPageMainPage.tsx
+++ b/src/pages/mypage/MyPageMainPage.tsx
@@ -33,9 +33,7 @@ function SummaryCard({ saved, over }: { saved: number; over: number }) {
             <span className="text-primary-50">절약</span>
             <span className="text-gray-10">한 기간</span>
           </p>
-          <p className="text-gray-10 mt-1 text-[15px] font-semibold">
-            {saved}회
-          </p>
+          <p className="mt-1 text-[15px] font-semibold text-gray-10">{saved}회</p>
         </div>
 
         <div className="text-right">
@@ -43,9 +41,7 @@ function SummaryCard({ saved, over }: { saved: number; over: number }) {
             <span className="text-primary-50">초과</span>
             <span className="text-gray-10">한 기간</span>
           </p>
-          <p className="text-gray-10 mt-1 text-[15px] font-semibold">
-            {over}회
-          </p>
+          <p className="mt-1 text-[15px] font-semibold text-gray-10">{over}회</p>
         </div>
       </div>
     </CommonCard>
@@ -72,7 +68,7 @@ export default function MyPageMainPage() {
 
   const summary: { saved: number; over: number } | null = useMemo(
     () => ({ saved: 6, over: 4 }),
-    [],
+    []
   );
 
   const user = {
@@ -96,7 +92,7 @@ export default function MyPageMainPage() {
       targetBudget: 0,
       spentAmount: 0,
     };
-  }, [currentRecord, emptyPeriod.endDate, emptyPeriod.startDate]);
+  }, [currentRecord, emptyPeriod.startDate, emptyPeriod.endDate]);
 
   return (
     <main className="flex h-full w-full flex-col">
@@ -130,10 +126,9 @@ export default function MyPageMainPage() {
         <p className="text-sub2 text-gray-10">
           {user.name}님은
           <br />
-          <span className="text-primary-50">모니핏</span>을 {user.used}{" "}
-          사용했어요
+          <span className="text-primary-50">모니핏</span>을 {user.used} 사용했어요
         </p>
-        <p className="text-caption2 text-gray-60 mt-2">{user.startText}</p>
+        <p className="mt-2 text-caption2 text-gray-60">{user.startText}</p>
       </section>
 
       <section className="mt-6 flex flex-col items-center gap-5 px-4">


### PR DESCRIPTION
## 🔍 관련된 이슈
- closed #48 

## 📝 작업 내용
- 진행 중인 지출 기록이 없을 때(0원 상태)에도 진행 카드(BudgetProgressCard)를 유지하고, 기간 게이지를 0%로 표시하도록 처리
- 0원 상태에서 기존 “목표 금액 xx원 절약했어요” 문구를 노출하지 않고, “아직 지출 기록이 없어요 …” 안내 문구로 분기
- 마이페이지 메인에서 Empty CommonCard 분기 제거 후 ProgressCard props를 0원/기간값으로 주입하도록 수정



## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되었고 빌드되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
