### PR TITLE
feat: ReportPage 페이지 API연동 및 라우팅 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SplashPage from "./pages/auth/SplashPage";
 import LoginPage from "./pages/auth/LoginPage";
 import CallbackPage from "./pages/auth/CallbackPage";
 import CalendarPage from "./pages/CalendarPage";
+import ReportPage from "./pages/ReportPage";
 import { MainPage } from "./pages";
 import { StampPage } from "./pages";
 import {
@@ -44,6 +45,8 @@ export default function App() {
             element={<BudgetSettingPage />}
           />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/report" element={<ReportPage />} />
+
 
           <Route path="/mypage" element={<MyPageMainPage />} />
           <Route path="/mypage/profile" element={<MyPageProfilePage />} />

--- a/src/api/budgetPeriod.ts
+++ b/src/api/budgetPeriod.ts
@@ -211,3 +211,58 @@ export const getCompletedBudgets = async (): Promise<CompletedPeriodItem[]> => {
     throw error;
   }
 };
+  // 지출 항목 타입 (리포트 도넛/카테고리 합산용)
+export interface ExpenseItem {
+  id: number;
+  category: string;
+  categoryName: string;
+  amount: number;
+  spentDate: string;
+  createdAt: string;
+}
+
+// 지출 목록 응답 타입
+interface ExpensesData {
+  expenses: ExpenseItem[];
+  totalCount: number;
+  totalAmount: number;
+}
+
+
+// 6. 지출 목록 조회 (리포트용)
+export const getExpenses = async (params?: {
+  periodId?: string | number;
+  date?: string;
+  category?: string;
+}): Promise<ExpensesData> => {
+  try {
+    const query = new URLSearchParams();
+    
+    if (params?.periodId !== undefined) query.set('periodId', String(params.periodId));
+    if (params?.date) query.set('date', params.date);
+    if (params?.category) query.set('category', params.category);
+
+    const queryString = query.toString();
+    const url = queryString
+      ? `${API_BASE_URL}/expenses?${queryString}`
+      : `${API_BASE_URL}/expenses`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${getAuthToken()}`,
+      }
+    });
+
+    const result: ApiResponse<ExpensesData> = await response.json();
+    
+    if (result.success && result.data) {
+      return result.data;
+    } else {
+      throw new Error(result.error?.message || '지출 목록 조회 실패');
+    }
+  } catch (error) {
+    console.error('getExpenses 오류:', error);
+    throw error;
+  }
+};
+

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { SVGProps } from "react";
 
 import CategoryList from "@/components/category/CategoryList";
 import { Button } from "@/components/common/Button";
@@ -16,8 +17,10 @@ import TintedHospitalIcon from "@/assets/icons/tinted/TintedHospitalIcon";
 import TintedHomeIcon from "@/assets/icons/tinted/TintedHomeIcon";
 import TintedStarIcon from "@/assets/icons/tinted/TintedStarIcon";
 
+import { getDashboard, getExpenses, type ExpenseItem } from "@/api/budgetPeriod";
+
 type PeriodOption = {
-  id: string;
+  id: number;
   primary: string;
   secondary: string;
 };
@@ -26,70 +29,213 @@ interface ReportPageProps {
   onClose?: () => void;
 }
 
+type CategoryKey = "food" | "shopping" | "medical" | "living" | "etc";
+
+type IconComponent = React.FC<SVGProps<SVGSVGElement>>;
+
+const CATEGORY_ORDER: Array<{ key: CategoryKey; label: string }> = [
+  { key: "food", label: "식비" },
+  { key: "shopping", label: "쇼핑" },
+  { key: "medical", label: "의료" },
+  { key: "living", label: "생활" },
+  { key: "etc", label: "기타" },
+];
+
+const CATEGORY_META: Record<
+  CategoryKey,
+  { color: string; labelColor: string; icon: IconComponent }
+> = {
+  food: {
+    color: "var(--color-gray-20)",
+    labelColor: "var(--color-gray-90)",
+    icon: TintedFoodIcon,
+  },
+  shopping: {
+    color: "var(--color-primary-50)",
+    labelColor: "var(--color-gray-90)",
+    icon: TintedShoppingIcon,
+  },
+  medical: {
+    color: "var(--color-gray-30)",
+    labelColor: "var(--color-gray-90)",
+    icon: TintedHospitalIcon,
+  },
+  living: {
+    color: "linear",
+    labelColor: "var(--color-gray-90)",
+    icon: TintedHomeIcon,
+  },
+  etc: {
+    color: "var(--color-gray-40)",
+    labelColor: "var(--color-gray-90)",
+    icon: TintedStarIcon,
+  },
+};
+
+function formatPeriodLabel(dateStr: string) {
+  if (!dateStr) return "";
+  return dateStr.slice(2).replaceAll("-", ".");
+}
+
+function normalizeCategoryKey(categoryName: string, categoryCode: string): CategoryKey {
+  const name = (categoryName || "").trim();
+
+  if (name.includes("식")) return "food";
+  if (name.includes("쇼")) return "shopping";
+  if (name.includes("의")) return "medical";
+  if (name.includes("생")) return "living";
+  if (name.includes("기")) return "etc";
+
+  const code = (categoryCode || "").toUpperCase();
+  if (code.includes("FOOD")) return "food";
+  if (code.includes("SHOP")) return "shopping";
+  if (code.includes("MED")) return "medical";
+  if (code.includes("LIFE") || code.includes("LIVING")) return "living";
+  if (code.includes("ETC") || code.includes("OTHER")) return "etc";
+
+  return "etc";
+}
+
+function buildDonutItems(expenses: ExpenseItem[]): DonutItem[] {
+  const sumByKey: Record<CategoryKey, number> = {
+    food: 0,
+    shopping: 0,
+    medical: 0,
+    living: 0,
+    etc: 0,
+  };
+
+  for (const e of expenses) {
+    const key = normalizeCategoryKey(e.categoryName, e.category);
+    sumByKey[key] += e.amount || 0;
+  }
+
+  return CATEGORY_ORDER.map(({ key, label }) => {
+    const meta = CATEGORY_META[key];
+    return {
+      id: key,
+      label,
+      value: sumByKey[key],
+      color: meta.color,
+      labelColor: meta.labelColor,
+      icon: meta.icon,
+    };
+  });
+}
+
 export const ReportPage = ({ onClose }: ReportPageProps) => {
-  const [isDetailOpen, setIsDetailOpen] = useState(true);
+  const [isDetailOpen] = useState(true);
   const [isPeriodOpen, setIsPeriodOpen] = useState(false);
-  const [selectedPeriodId, setSelectedPeriodId] = useState("p1");
 
-  const periodOptions: PeriodOption[] = useMemo(
-    () => [
-      { id: "p1", primary: "26.01.01 - 26.01.30", secondary: "이번 달" },
-      { id: "p2", primary: "25.12.01 - 25.12.31", secondary: "지난 달" },
-      { id: "p3", primary: "25.11.01 - 25.11.30", secondary: "2개월 전" },
-    ],
-    [],
-  );
+  const [loading, setLoading] = useState(true);
+  const [hasPeriod, setHasPeriod] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const donutItems: DonutItem[] = useMemo(
-    () => [
-      {
-        id: "food",
-        label: "식비",
-        value: 135000,
-        color: "var(--color-gray-20)",
-        labelColor: "var(--color-gray-90)",
-        icon: TintedFoodIcon,
-      },
-      {
-        id: "shopping",
-        label: "쇼핑",
-        value: 135000,
-        color: "var(--color-primary-50)",
-        labelColor: "var(--color-gray-90)",
-        icon: TintedShoppingIcon,
-      },
-      {
-        id: "medical",
-        label: "의료",
-        value: 135000,
-        color: "var(--color-gray-30)",
-        labelColor: "var(--color-gray-90)",
-        icon: TintedHospitalIcon,
-      },
-      {
-        id: "living",
-        label: "생활",
-        value: 135000,
-        color: "linear",
-        labelColor: "var(--color-gray-90)",
-        icon: TintedHomeIcon,
-      },
-      {
-        id: "etc",
-        label: "기타",
+  const [periodOptions, setPeriodOptions] = useState<PeriodOption[]>([]);
+  const [selectedPeriodId, setSelectedPeriodId] = useState<number | null>(null);
+
+  const [budgetValue, setBudgetValue] = useState(0);
+  const [totalValue, setTotalValue] = useState(0);
+  const [savedAmount, setSavedAmount] = useState(0);
+  const [exceededAmount, setExceededAmount] = useState(0);
+
+  const [donutItems, setDonutItems] = useState<DonutItem[]>(() =>
+    CATEGORY_ORDER.map(({ key, label }) => {
+      const meta = CATEGORY_META[key];
+      return {
+        id: key,
+        label,
         value: 0,
-        color: "var(--color-gray-40)",
-        labelColor: "var(--color-gray-90)",
-        icon: TintedStarIcon,
-      },
-    ],
-    [],
+        color: meta.color,
+        labelColor: meta.labelColor,
+        icon: meta.icon,
+      };
+    }),
   );
 
-  const totalValue = useMemo(
+  const computedTotal = useMemo(
     () => donutItems.reduce((acc, it) => acc + (it.value ?? 0), 0),
     [donutItems],
   );
+
+  const resultText = useMemo(() => {
+    if (exceededAmount > 0) return `${exceededAmount.toLocaleString()}원 초과 ⚠`;
+    return `${savedAmount.toLocaleString()}원 절약 🎉`;
+  }, [savedAmount, exceededAmount]);
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        setLoading(true);
+        setErrorMessage(null);
+
+        const dash = await getDashboard();
+
+        if (!dash.hasPeriod || !dash.period) {
+          setHasPeriod(false);
+          setDonutItems(buildDonutItems([]));
+          return;
+        }
+
+        setHasPeriod(true);
+
+        const period = dash.period;
+        const periodId = Number(period.id);
+
+        setSelectedPeriodId(periodId);
+        setBudgetValue(period.budgetAmount ?? 0);
+        setTotalValue(period.totalExpense ?? 0);
+        setSavedAmount((period.savedAmount ?? 0) as number);
+        setExceededAmount((period.exceededAmount ?? 0) as number);
+
+        const start = formatPeriodLabel(period.startDate);
+        const end = formatPeriodLabel(period.endDate);
+
+        setPeriodOptions((prev) => {
+          if (prev.length > 0) return prev;
+          return [
+            {
+              id: periodId,
+              primary: `${start} - ${end}`,
+              secondary: "현재 기간",
+            },
+          ];
+        });
+
+        const exp = await getExpenses({ periodId });
+        setDonutItems(buildDonutItems(exp.expenses ?? []));
+      } catch (e: unknown) {
+        setHasPeriod(false);
+        setDonutItems(buildDonutItems([]));
+        setErrorMessage(e instanceof Error ? e.message : "리포트 데이터를 불러오지 못했어요.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    init();
+  }, []);
+
+  useEffect(() => {
+    const refetch = async () => {
+      if (!selectedPeriodId) return;
+
+      try {
+        setLoading(true);
+        setErrorMessage(null);
+
+        const exp = await getExpenses({ periodId: selectedPeriodId });
+        setDonutItems(buildDonutItems(exp.expenses ?? []));
+      } catch (e: unknown) {
+        setDonutItems(buildDonutItems([]));
+        setErrorMessage(e instanceof Error ? e.message : "지출 데이터를 불러오지 못했어요.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    refetch();
+  }, [selectedPeriodId]);
 
   return (
     <div className="relative z-50 flex h-screen w-full flex-col items-center bg-black pt-20">
@@ -140,19 +286,8 @@ export const ReportPage = ({ onClose }: ReportPageProps) => {
                     ].join(" ")}
                   >
                     <div className="mt-0.5 shrink-0">
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                      >
-                        <circle
-                          cx="12"
-                          cy="12"
-                          r="9"
-                          stroke="#3B82F6"
-                          strokeWidth="2"
-                        />
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="9" stroke="#3B82F6" strokeWidth="2" />
                         <path
                           d="M12 8v5l3 2"
                           stroke="#3B82F6"
@@ -164,12 +299,8 @@ export const ReportPage = ({ onClose }: ReportPageProps) => {
                     </div>
 
                     <div className="flex flex-col leading-tight">
-                      <span className="text-[12px] text-white/90">
-                        {opt.primary}
-                      </span>
-                      <span className="mt-1 text-[12px] text-white/70">
-                        {opt.secondary}
-                      </span>
+                      <span className="text-[12px] text-white/90">{opt.primary}</span>
+                      <span className="mt-1 text-[12px] text-white/70">{opt.secondary}</span>
                     </div>
                   </button>
                 </li>
@@ -191,14 +322,11 @@ export const ReportPage = ({ onClose }: ReportPageProps) => {
         </button>
       </div>
 
-      <section
-        className="flex h-73.75 w-93.75 shrink-0 items-center justify-center bg-transparent"
-        onClick={() => setIsDetailOpen(true)}
-      >
+      <section className="flex h-73.75 w-93.75 shrink-0 items-center justify-center bg-transparent">
         <DonutChart
           items={donutItems}
-          totalValue={totalValue}
-          budgetValue={400000}
+          totalValue={totalValue || computedTotal}
+          budgetValue={budgetValue || 0}
           size={260}
           innerRadius={78}
           minThickness={36}
@@ -214,32 +342,55 @@ export const ReportPage = ({ onClose }: ReportPageProps) => {
         />
       </section>
 
+      {loading && <div className="w-93.75 px-4 pt-3 text-[12px] text-white/60">불러오는 중...</div>}
+
+      {!loading && !hasPeriod && (
+        <div className="w-93.75 px-4 pt-3 text-[12px] text-white/60">표시할 리포트 기간이 없어요.</div>
+      )}
+
+      {!loading && hasPeriod && (
+        <div className="w-93.75 px-4 pt-2 text-[14px] text-white/90">{resultText}</div>
+      )}
+
+      {errorMessage && <div className="w-93.75 px-4 pt-2 text-[12px] text-red-300">{errorMessage}</div>}
+
       {isDetailOpen && (
         <section className="w-93.75 flex-1 overflow-y-auto bg-[#121212] px-4 pb-20">
-          <CategoryList />
+          <div className="space-y-3 pt-4">
+            {donutItems.map((it) => {
+              const Icon = it.icon as IconComponent | undefined;
+
+              return (
+                <div key={it.id} className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="grid h-7 w-7 place-items-center rounded-full bg-white/5">
+                      {Icon ? <Icon /> : null}
+                    </div>
+                    <div className="text-[14px] text-white/90">{it.label}</div>
+                  </div>
+                  <div className="text-[14px] text-white/80">
+                    총 {Number(it.value ?? 0).toLocaleString()}원 지출
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="pt-6">
+            <CategoryList />
+          </div>
         </section>
       )}
 
       <div className="fixed bottom-8 w-93.75 px-6">
         <div className="flex items-center justify-between">
           <div className="bg-primary-opacity-50 flex rounded-full border border-white/10 p-1">
-            <Button
-              width={"sm"}
-              borderColor={"outline"}
-              bgColor={"none"}
-              className="flex gap-2"
-              fontColor={"white"}
-            >
+            <Button width={"sm"} borderColor={"outline"} bgColor={"none"} className="flex gap-2" fontColor={"white"}>
               <CalendarIcon />
               달력
             </Button>
 
-            <Button
-              width={"md"}
-              borderColor={"outline"}
-              bgColor={"none"}
-              className="flex gap-2 bg-white"
-            >
+            <Button width={"md"} borderColor={"outline"} bgColor={"none"} className="flex gap-2 bg-white">
               <ReportIcon />
               리포트
             </Button>


### PR DESCRIPTION
## 🔍 관련된 이슈

- closed #issue number

## 📝 작업 내용
- `GET /api/v1/dashboard` API 연동
  - 총 지출 금액
  - 목표 예산
  - 절약 / 초과 금액 문구 표시
- `GET /api/v1/expenses?periodId=` API 연동
- 지출 데이터를 카테고리별로 그룹화 및 금액 합산
- 도넛 차트용 카테고리별 비율 데이터 가공
- 카테고리별 총 지출 리스트 UI 연결
- 로딩 상태 및 데이터 없음(`hasPeriod=false`) 분기 처리
- `/report` 라우트 추가 및 페이지 연결

---

## 🚨 이슈
- 현재 `GET /api/v1/dashboard` 호출 시 **401 Unauthorized** 응답이 발생합니다.
- Authorization 헤더는 포함되어 있으나,
  로컬 환경에서 **로그인 플로우 자체를 정상적으로 탈 수 없는 상태**입니다.


---

## 📸 스크린샷
<img width="563" height="689" alt="스크린샷 2026-02-10 오전 2 36 49" src="https://github.com/user-attachments/assets/8403b9c6-7dc8-4462-a29f-880ff5d0734a" />
<img width="563" height="689" alt="스크린샷 2026-02-10 오전 2 36 49" src="https://github.com/user-attachments/assets/8403b9c6-7dc8-4462-a29f-880ff5d0734a" />
<img width="711" height="47" alt="스크린샷 2026-02-10 오전 2 37 29" src="https://github.com/user-attachments/assets/a377d54a-a1fb-4689-a391-e18b3e6c7946" />
<img width="711" height="47" alt="스크린샷 2026-02-10 오전 2 37 29" sr
<img width="974" height="991" alt="스크린샷 2026-02-10 오전 2 37 45" src="https://github.com/user-attachments/assets/458b18ae-1120-4438-9861-3fc4dfd86143" />
<img width="974" height="991" alt="스크린샷 2026-02-10 오전 2 37 45" src="https://github.com/user-attachments/assets/458b18ae-1120-4438-9861-3fc4dfd86143" />
c="https://github.com/user-attachments/assets/a377d54a-a1fb-4689-a391-e18b3e6c7946" />


- 카카오 로그인을 시도하면  
  `앱 관리자 설정 오류 (KOE101)` 화면으로 이동되어 로그인이 불가능하다고 뜹니다ㅠㅜ그래서 인증이 필요한 API의 실제 정상 동작을 확인하지 못하고 있습니다,,,

---

## 📣 리뷰 요구사항
> 현재 401 오류로 인해 API 정상 응답을 확인하지 못하고 있습니다.  
> 어떻게 해야 동작 확인이 가능할까요ㅠㅠ?

---
## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되었고 빌드되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
