### PR TITLE
style: html, body 태그에 최대 너비/높이 제약 적용 및 MobileLayout 단순화

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,16 @@
 @import "./styles/typography.css";
 
 html,
-body,
+body {
+  max-width: 376px;
+  max-height: 812px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0;
+  overflow: hidden;
+  background-color: #1c1c1e;
+}
+
 #root {
   height: 100%;
   margin: 0;

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -2,10 +2,8 @@ import { Outlet } from "react-router-dom";
 
 export default function MobileLayout() {
   return (
-    <div className="flex min-h-dvh justify-center bg-[#1f1f1f]">
-      <main className="flex h-dvh max-h-[812px] w-[375px] flex-col overflow-hidden">
-        <Outlet />
-      </main>
-    </div>
+    <main className="flex h-full max-h-[812px] w-full max-w-[376px] flex-col overflow-hidden">
+      <Outlet />
+    </main>
   );
 }


### PR DESCRIPTION
## 🔀 Pull Request Title

`style: html, body 태그에 최대 너비/높이 제약 적용 및 MobileLayout 단순화`

<br>

## 📌 PR 설명

모든 화면에서 최대 너비 376px, 최대 높이 812px로 고정되도록 레이아웃을 수정했습니다.

- [x] `App.css`의 html, body 태그에 `max-width: 376px`, `max-height: 812px` 제약 추가
- [x] html, body에 `margin: 0 auto`, `overflow: hidden`, `background-color` 적용
- [x] `MobileLayout.tsx`에서 불필요한 래퍼 div 제거 및 구조 단순화

<br>

## 📷 스크린샷

UI 구조 변경이며 시각적 차이는 없습니다.

<br>

## 🔍 추가 설명

- 기존에는 MobileLayout 컴포넌트 내부에서만 크기를 제한했으나, html/body 레벨에서 제약을 걸어 모든 화면에서 일관된 크기가 보장됩니다.
- MobileLayout의 외부 래퍼 div가 담당하던 정렬/배경색 역할을 html, body로 이동시켜 컴포넌트를 단순화했습니다.