### PR TITLE
style: 모바일 레이아웃 최대 크기 제약 적용

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,16 @@
 @import "./styles/typography.css";
 
 html,
-body,
+body {
+  max-width: 376px;
+  max-height: 812px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0;
+  overflow: hidden;
+  background-color: #1c1c1e;
+}
+
 #root {
   height: 100%;
   margin: 0;

--- a/src/layouts/MobileLayout.tsx
+++ b/src/layouts/MobileLayout.tsx
@@ -2,10 +2,8 @@ import { Outlet } from "react-router-dom";
 
 export default function MobileLayout() {
   return (
-    <div className="flex min-h-dvh justify-center bg-[#1f1f1f]">
-      <main className="flex h-dvh max-h-[812px] w-[375px] flex-col overflow-hidden">
-        <Outlet />
-      </main>
-    </div>
+    <main className="flex h-full max-h-[812px] w-full max-w-[376px] flex-col overflow-hidden">
+      <Outlet />
+    </main>
   );
 }


### PR DESCRIPTION
## 🔀 Pull Request Title

`style: 모바일 레이아웃 최대 크기 제약 적용`

<br>

## 📌 PR 설명

develop 브랜치의 변경사항을 main에 머지합니다.

- [x] html, body 태그에 `max-width: 376px`, `max-height: 812px` 제약 추가 (#83)
- [x] MobileLayout 컴포넌트 구조 단순화 (불필요한 래퍼 div 제거)

<br>

## 📷 스크린샷

UI 구조 변경이며 시각적 차이는 없습니다.

<br>

## 🔍 추가 설명

- html/body 레벨에서 크기를 제한하여 모든 화면에서 376x812px 고정 레이아웃이 보장됩니다.