### PR TITLE
fix: 구체 영역 배경색 통일

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -86,7 +86,7 @@ export const MainPage = () => {
 
   const gradientCenter = mixColor(
     "#7976FF",
-    "#1F1F1F",
+    "#1C1C1E",
     1 - fillRatio
   );
 
@@ -212,7 +212,7 @@ export const MainPage = () => {
         <div
           className="relative h-90 w-90"
           style={{
-            background: `radial-gradient(circle at center, ${gradientCenter} 0%, #1F1F1F 49%)`,
+            background: `radial-gradient(circle at center, ${gradientCenter} 0%, #1C1C1E 49%)`,
           }}
         >
           <Canvas>


### PR DESCRIPTION
## 🔀 Pull Request Title

`fix: 구체 영역 배경색 통일`

<br>

## 📌 PR 설명

메인 페이지 구체 영역의 radial-gradient 배경색이 페이지 배경색과 달라 경계가 보이는 문제를 수정했습니다.

- [x] radial-gradient 끝 색상을 `#1F1F1F` -> `#1C1C1E`로 변경하여 페이지 배경색과 통일
- [x] mixColor 기준 색상도 동일하게 `#1C1C1E`로 변경

<br>

## 📷 스크린샷

구체 영역과 배경 사이의 색상 차이가 제거됩니다.

<br>

## 🔍 추가 설명

- 기존에 구체 gradient 색상(`#1F1F1F`)과 페이지 배경색(`#1C1C1E`)이 달라 경계가 눈에 띄었습니다.